### PR TITLE
Fix background in devices list

### DIFF
--- a/themes/blue_night.yaml
+++ b/themes/blue_night.yaml
@@ -6,6 +6,7 @@ blue_night:
   accent-color: "hsl(var(--huesat) 30%)"
   base-hue: "220"
   base-sat: "5%"
+  card-background-color: "var(--paper-card-background-color)"
   dark-divider-opacity: "0"
   dark-primary-color: "hsl(var(--huesat) 60%)"
   dark-secondary-opacity: "1"


### PR DESCRIPTION
As per home-assistant-community-themes/grey-night#6, fix the colour of device lists.