### PR TITLE
Add rgb-primary-text-color to fix missing Hover effect

### DIFF
--- a/themes/blue_night.yaml
+++ b/themes/blue_night.yaml
@@ -86,3 +86,4 @@ blue_night:
   table-row-alternative-background-color: "hsl(var(--huesat) 10%)"
   table-row-background-color: "hsl(var(--huesat) 12%)"
   text-primary-color: "hsl(var(--huesat) 90%)"
+  rgb-primary-text-color: "0, 120 , 160"

--- a/themes/blue_night.yaml
+++ b/themes/blue_night.yaml
@@ -76,6 +76,7 @@ blue_night:
   primary-background-color: "hsl(var(--huesat) 16%)"
   primary-color: "#2581ab"
   primary-text-color: "hsl(var(--huesat) 90%)"
+  rgb-primary-text-color: "0, 120 , 160"
   secondary-background-color: "hsl(var(--huesat) 16%)"
   secondary-text-color: "hsl(var(--huesat) 80%)"
   shadow-elevation-16dp_-_box-shadow: "0px 0px 0px 0px hsl(var(--huesat) 25%)"
@@ -86,4 +87,4 @@ blue_night:
   table-row-alternative-background-color: "hsl(var(--huesat) 10%)"
   table-row-background-color: "hsl(var(--huesat) 12%)"
   text-primary-color: "hsl(var(--huesat) 90%)"
-  rgb-primary-text-color: "0, 120 , 160"
+


### PR DESCRIPTION
Add rgb-primary-text-color to fix missing Hover effect
Closes issue: https://github.com/home-assistant-community-themes/blue-night/issues/18 and also https://github.com/home-assistant/frontend/issues/7136

The rgb value is needed for the hover effect, this variable is used inside a rgba function, if the value is missing the hover effect fails.