### PR TITLE
Unbreak theme from latest HomeAssistant changes

### DIFF
--- a/themes/blue_night.yaml
+++ b/themes/blue_night.yaml
@@ -4,6 +4,7 @@
 #
 blue_night:
   accent-color: "hsl(var(--huesat) 30%)"
+  amber-color: "#fdd835"
   base-hue: "220"
   base-sat: "5%"
   card-background-color: "var(--paper-card-background-color)"
@@ -64,6 +65,7 @@ blue_night:
   paper-input-container-color: "hsl(var(--huesat) 60%)"
   paper-item-icon-color: "hsl(var(--huesat) 40%)"
   paper-item-icon_-_color: "var(--paper-item-icon-color)"
+  paper-item-icon-active-color: "var(--state-icon-active-color)"
   paper-item-selected_-_background-color: "hsla(0, 0%, 0%, 0.2)"
   paper-item-selected_-_color: "hsl(var(--huesat) 20%)"
   paper-listbox-background-color: "hsl(var(--huesat) 16%)"
@@ -93,6 +95,7 @@ blue_night:
   sidebar-icon-color: "hsl(var(--huesat) 50%)"
   sidebar-text-color: "hsl(var(--huesat) 90%)"
   sidebar-text_-_color: "hsl(var(--huesat) 90%)"
+  state-icon-active-color: "var(--amber-color)"
   table-row-alternative-background-color: "hsl(var(--huesat) 10%)"
   table-row-background-color: "hsl(var(--huesat) 12%)"
   text-primary-color: "hsl(var(--huesat) 90%)"


### PR DESCRIPTION
Fix icon colors to keep consistency as expected from this theme, since latest home assistant changes had a breaking change regard css variables. This commit brings the original colors back.

Specially important when using custom cards.

![image](https://user-images.githubusercontent.com/25059996/215026391-7e21e51a-e85b-40c2-adcf-574af90889d1.png)

The active state icon used to be yellow `#fdd835`, and that is what was lost.

