### PR TITLE
Fix unavailable state icon color

### DIFF
--- a/themes/blue_night.yaml
+++ b/themes/blue_night.yaml
@@ -96,6 +96,7 @@ blue_night:
   sidebar-text-color: "hsl(var(--huesat) 90%)"
   sidebar-text_-_color: "hsl(var(--huesat) 90%)"
   state-icon-active-color: "var(--amber-color)"
+  state-unavailable-color: "var(--paper-item-icon-color)"
   table-row-alternative-background-color: "hsl(var(--huesat) 10%)"
   table-row-background-color: "hsl(var(--huesat) 12%)"
   text-primary-color: "hsl(var(--huesat) 90%)"


### PR DESCRIPTION
When the state of the entity was unavailable, the icon color would render brighter than the regular icons. Change that to be the same color, so the whole interface looks consistent.

Fix issue: #37